### PR TITLE
Add `aud` validation for JAR requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,14 +474,14 @@ Library currently supports `response_type` equal to `vp_token`
 
 ### Request Object Audience Check
 
-By default, the library **does not** verify the Audience of the Resolved Request Object. To enable it, 
-set `SignedRequestConfiguration.requestObjectAudienceCheckEnabled` to `true`.
-
-When enabled, the library will ensure the Audience of the Resolved Request Object is:
+By default, the library verifies the Audience of the Resolved Request Object is:
 
 * `https://self-issued.me/v2` when Request URI Method `GET` was used
 * `https://self-issued.me/v2` when Request URI Method `POST` was used and **NO** Wallet Metadata were included in the request
 * The value of `SupportedRequestUriMethods.Post.issuer` when Request URI Method `POST` was used and Wallet Metadata were included in the request
+
+
+To disable this check, set `SignedRequestConfiguration.requestObjectAudienceCheckEnabled` to `false`.
 
 Example configuration:
 

--- a/README.md
+++ b/README.md
@@ -472,6 +472,33 @@ Library parses and validates the verifier metadata.
 
 Library currently supports `response_type` equal to `vp_token`
 
+### Request Object Audience Check
+
+By default, the library **does not** verify the Audience of the Resolved Request Object. To enable it, 
+set `SignedRequestConfiguration.requestObjectAudienceCheckEnabled` to `true`.
+
+When enabled, the library will ensure the Audience of the Resolved Request Object is:
+
+* `https://self-issued.me/v2` when Request URI Method `GET` was used
+* `https://self-issued.me/v2` when Request URI Method `POST` was used and **NO** Wallet Metadata were included in the request
+* The value of `SupportedRequestUriMethods.Post.issuer` when Request URI Method `POST` was used and Wallet Metadata were included in the request
+
+Example configuration:
+
+```kotlin
+OpenId4VPConfig(
+    ...,
+    signedRequestConfiguration = SignedRequestConfiguration(
+        ...,
+        supportedRequestUriMethods = SupportedRequestUriMethods.Post(
+            ...,
+            issuer = Issuer("eudi_wallet"),
+        ),
+        requestObjectAudienceCheckEnabled = true,
+    ),
+)
+```
+
 ## How to contribute
 
 We welcome contributions to this project. To ensure that the process is smooth for everyone

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -392,14 +392,14 @@ sealed interface MultiSignedRequestsPolicy {
  * @param supportedRequestUriMethods which of the `request_uri_method` methods are supported
  * @param multiSignedRequestsPolicy whether the wallet supports multi-signed requests and if so, what is the expected client prefix
  * @param clockSkew max acceptable skew between wallet and verifier when performing request signature validation, up to 60 sec. Defaults to 15 sec
- * @param requestObjectAudienceCheckEnabled whether the audience of the request object is checked or not, defaults to `false`
+ * @param requestObjectAudienceCheckEnabled whether the audience of the request object is checked or not, defaults to `true`
  */
 data class SignedRequestConfiguration(
     val supportedAlgorithms: List<JWSAlgorithm>,
     val supportedRequestUriMethods: SupportedRequestUriMethods = SupportedRequestUriMethods.Default,
     val multiSignedRequestsPolicy: MultiSignedRequestsPolicy = MultiSignedRequestsPolicy.NotSupported,
     val clockSkew: Duration = Duration.ofSeconds(15L),
-    val requestObjectAudienceCheckEnabled: Boolean = false,
+    val requestObjectAudienceCheckEnabled: Boolean = true,
 ) {
     init {
         require(supportedAlgorithms.isNotEmpty()) { "JAR signing algorithms cannot be empty" }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -487,7 +487,7 @@ fun interface RegistrationCertificatePolicy {
  *
  * At minimum, a wallet configuration should define at least a [supportedClientIdPrefixes]
  *
- * @param issuer an optional id for the wallet. If not provided defaults to [SelfIssued].
+ * @param issuer an id for the wallet, defaults to [SelfIssued].
  * @param signedRequestConfiguration options related to JWT Secure authorization requests.
  * If not provided, it will default to [SignedRequestConfiguration.Default]
  * @param responseEncryptionConfiguration whether wallet supports authorization response encryption. If not specified, it takes the default value
@@ -501,7 +501,7 @@ fun interface RegistrationCertificatePolicy {
  * @param registrationCertificatePolicy wallet's policy regarding Wallet Relying Party Registration Certificates processing
  */
 data class OpenId4VPConfig(
-    val issuer: Issuer? = SelfIssued,
+    val issuer: Issuer = SelfIssued,
     val signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
     val responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
     val knownDCQLQueriesPerScope: Map<String, DCQL> = emptyMap(),
@@ -532,7 +532,7 @@ data class OpenId4VPConfig(
     }
 
     constructor(
-        issuer: Issuer? = SelfIssued,
+        issuer: Issuer = SelfIssued,
         signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
         responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
         knownDCQLQueriesPerScope: Map<String, DCQL> = emptyMap(),
@@ -557,7 +557,7 @@ data class OpenId4VPConfig(
 
     @Deprecated(message = "VPConfiguration merged in OpenId4VPConfig", replaceWith = ReplaceWith("OpenId4VPConfig"))
     constructor(
-        issuer: Issuer? = SelfIssued,
+        issuer: Issuer = SelfIssued,
         signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
         responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
         vpConfiguration: VPConfiguration,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -487,7 +487,7 @@ fun interface RegistrationCertificatePolicy {
  *
  * At minimum, a wallet configuration should define at least a [supportedClientIdPrefixes]
  *
- * @param issuer an id for the wallet, defaults to [SelfIssued].
+ * @param issuer an optional id for the wallet. If not provided defaults to [SelfIssued].
  * @param signedRequestConfiguration options related to JWT Secure authorization requests.
  * If not provided, it will default to [SignedRequestConfiguration.Default]
  * @param responseEncryptionConfiguration whether wallet supports authorization response encryption. If not specified, it takes the default value
@@ -501,7 +501,7 @@ fun interface RegistrationCertificatePolicy {
  * @param registrationCertificatePolicy wallet's policy regarding Wallet Relying Party Registration Certificates processing
  */
 data class OpenId4VPConfig(
-    val issuer: Issuer = SelfIssued,
+    val issuer: Issuer? = SelfIssued,
     val signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
     val responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
     val knownDCQLQueriesPerScope: Map<String, DCQL> = emptyMap(),
@@ -532,7 +532,7 @@ data class OpenId4VPConfig(
     }
 
     constructor(
-        issuer: Issuer = SelfIssued,
+        issuer: Issuer? = SelfIssued,
         signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
         responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
         knownDCQLQueriesPerScope: Map<String, DCQL> = emptyMap(),
@@ -557,7 +557,7 @@ data class OpenId4VPConfig(
 
     @Deprecated(message = "VPConfiguration merged in OpenId4VPConfig", replaceWith = ReplaceWith("OpenId4VPConfig"))
     constructor(
-        issuer: Issuer = SelfIssued,
+        issuer: Issuer? = SelfIssued,
         signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
         responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
         vpConfiguration: VPConfiguration,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -23,6 +23,7 @@ import com.nimbusds.jose.crypto.ECDHDecrypter
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.oauth2.sdk.id.Issuer
+import eu.europa.ec.eudi.openid4vp.OpenId4VPConfig.Companion.SelfIssued
 import eu.europa.ec.eudi.openid4vp.ResponseEncryptionConfiguration.NotSupported
 import eu.europa.ec.eudi.openid4vp.dcql.DCQL
 import java.net.URI
@@ -326,15 +327,23 @@ sealed interface SupportedRequestUriMethods {
      * @param includeWalletMetadata whether to include wallet metadata or not
      * @param jarEncryption whether to request JAR be encrypted or not
      * @param useWalletNonce whether to use wallet_nonce
+     * @param issuer the unique identifier of the wallet, defaults to [SelfIssued]
      */
     data class Post(
         val includeWalletMetadata: Boolean = true,
         val jarEncryption: EncryptionRequirement = EncryptionRequirement.NotRequired,
         val useWalletNonce: NonceOption = NonceOption.Use(),
+        val issuer: Issuer? = SelfIssued,
     ) : SupportedRequestUriMethods {
         init {
             require(EncryptionRequirement.NotRequired == jarEncryption || includeWalletMetadata) {
                 "Wallet Metadata must be included when JAR encryption is required"
+            }
+
+            if (includeWalletMetadata) {
+                requireNotNull(issuer) {
+                    "Issuer must be provided when Wallet Metadata is sent"
+                }
             }
         }
     }
@@ -383,12 +392,14 @@ sealed interface MultiSignedRequestsPolicy {
  * @param supportedRequestUriMethods which of the `request_uri_method` methods are supported
  * @param multiSignedRequestsPolicy whether the wallet supports multi-signed requests and if so, what is the expected client prefix
  * @param clockSkew max acceptable skew between wallet and verifier when performing request signature validation, up to 60 sec. Defaults to 15 sec
+ * @param requestObjectAudienceCheckEnabled whether the audience of the request object is checked or not, defaults to `false`
  */
 data class SignedRequestConfiguration(
     val supportedAlgorithms: List<JWSAlgorithm>,
     val supportedRequestUriMethods: SupportedRequestUriMethods = SupportedRequestUriMethods.Default,
     val multiSignedRequestsPolicy: MultiSignedRequestsPolicy = MultiSignedRequestsPolicy.NotSupported,
     val clockSkew: Duration = Duration.ofSeconds(15L),
+    val requestObjectAudienceCheckEnabled: Boolean = false,
 ) {
     init {
         require(supportedAlgorithms.isNotEmpty()) { "JAR signing algorithms cannot be empty" }
@@ -501,7 +512,7 @@ fun interface RegistrationCertificatePolicy {
  * @param registrationCertificatePolicy wallet's policy regarding Wallet Relying Party Registration Certificates processing
  */
 data class OpenId4VPConfig(
-    val issuer: Issuer? = SelfIssued,
+    @Deprecated("Unused property. Use SupportedRequestUriMethods.Post.issuer instead.") val issuer: Issuer? = SelfIssued,
     val signedRequestConfiguration: SignedRequestConfiguration = SignedRequestConfiguration.Default,
     val responseEncryptionConfiguration: ResponseEncryptionConfiguration = NotSupported,
     val knownDCQLQueriesPerScope: Map<String, DCQL> = emptyMap(),
@@ -527,13 +538,6 @@ data class OpenId4VPConfig(
         if (null == vpFormatsSupported.sdJwtVc) {
             require(supportedTransactionDataTypes.none { it is SupportedTransactionDataType.SdJwtVc }) {
                 "SD-JWT VC Transaction Data cannot be used when SD-JWT VC is not supported"
-            }
-        }
-
-        val postOptions = signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()
-        if (null != postOptions && postOptions.includeWalletMetadata) {
-            requireNotNull(issuer) {
-                "Wrong configuration. Issuer must be provided when using Request URI Method POST and including Wallet Metadata."
             }
         }
     }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Config.kt
@@ -529,6 +529,13 @@ data class OpenId4VPConfig(
                 "SD-JWT VC Transaction Data cannot be used when SD-JWT VC is not supported"
             }
         }
+
+        val postOptions = signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()
+        if (null != postOptions && postOptions.includeWalletMetadata) {
+            requireNotNull(issuer) {
+                "Wrong configuration. Issuer must be provided when using Request URI Method POST and including Wallet Metadata."
+            }
+        }
     }
 
     constructor(

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Specs.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Specs.kt
@@ -113,3 +113,10 @@ object ETSI119472Part2 {
 object ETSI119475 {
     const val REG_CERT_HEADER_TYPE = "rc-wrp+jwt"
 }
+
+/**
+ * [OAuth 2.0 Authorization Server Metadata](https://www.rfc-editor.org/rfc/rfc8414.txt)
+ */
+object RFC8414 {
+    const val ISSUER: String = "issuer"
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Specs.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/Specs.kt
@@ -120,3 +120,10 @@ object ETSI119475 {
 object RFC8414 {
     const val ISSUER: String = "issuer"
 }
+
+/**
+ * [JSON Web Token (JWT)](https://www.rfc-editor.org/rfc/rfc7519.html)
+ */
+object RFC7519 {
+    const val AUDIENCE: String = "aud"
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
@@ -99,7 +99,7 @@ internal class RequestFetcher(
             } else jwt
 
             val audience =
-                if (null != walletMetaData) openId4VPConfig.issuer.value
+                if (null != walletMetaData) checkNotNull(openId4VPConfig.issuer?.value)
                 else SelfIssued.value
 
             return Triple(signedJwt, walletNonce, audience)

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
@@ -98,7 +98,11 @@ internal class RequestFetcher(
                 jwt.decrypt(ephemeralJarEncryptionKey!!, postOptions.jarEncryption).getOrThrow()
             } else jwt
 
-            return Triple(signedJwt, walletNonce, openId4VPConfig.issuer.value)
+            val audience =
+                if (null != walletMetaData) openId4VPConfig.issuer.value
+                else SelfIssued.value
+
+            return Triple(signedJwt, walletNonce, audience)
         }
 
         return when (requestUriMethod) {

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
@@ -23,6 +23,7 @@ import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.openid.connect.sdk.Nonce
 import eu.europa.ec.eudi.openid4vp.*
+import eu.europa.ec.eudi.openid4vp.OpenId4VPConfig.Companion.SelfIssued
 import eu.europa.ec.eudi.openid4vp.internal.ensure
 import eu.europa.ec.eudi.openid4vp.internal.ensureNotNull
 import io.ktor.client.*
@@ -48,33 +49,33 @@ internal class RequestFetcher(
     suspend fun fetchRequest(request: UnvalidatedRequest): ReceivedRequest = when (request) {
         is UnvalidatedRequest.Plain -> ReceivedRequest.Unsigned(request.requestObject)
         is UnvalidatedRequest.JwtSecured -> {
-            val (jwt, walletNonce) = when (request) {
-                is UnvalidatedRequest.JwtSecured.PassByValue -> request.jwt to null
-                is UnvalidatedRequest.JwtSecured.PassByReference -> fetchJwtAndWalletNonce(request)
+            val (jwt, walletNonce, audience) = when (request) {
+                is UnvalidatedRequest.JwtSecured.PassByValue -> Triple(request.jwt, null, SelfIssued.value)
+                is UnvalidatedRequest.JwtSecured.PassByReference -> fetchJwtWalletNonceAndAudience(request)
             }
             with(openId4VPConfig) {
-                ensureValid(expectedClient = request.clientId, expectedWalletNonce = walletNonce, unverifiedJwt = jwt)
+                ensureValid(expectedClient = request.clientId, walletNonce, expectedAudience = audience, unverifiedJwt = jwt)
             }
         }
     }
 
-    private suspend fun fetchJwtAndWalletNonce(
+    private suspend fun fetchJwtWalletNonceAndAudience(
         request: UnvalidatedRequest.JwtSecured.PassByReference,
-    ): Pair<Jwt, Nonce?> {
+    ): Triple<Jwt, Nonce?, String> {
         val (_, requestUri, requestUriMethod) = request
 
         val supportedMethods =
             openId4VPConfig.signedRequestConfiguration.supportedRequestUriMethods
         val postOptions = supportedMethods.isPostSupported()
 
-        suspend fun useGET(): Pair<Jwt, Nonce?> {
+        suspend fun useGET(): Triple<Jwt, Nonce?, String> {
             ensure(supportedMethods.isGetSupported()) {
                 unsupportedRequestUriMethod(RequestUriMethod.GET)
             }
-            return httpClient.getJAR(requestUri) to null
+            return Triple(httpClient.getJAR(requestUri), null, SelfIssued.value)
         }
 
-        suspend fun usePOST(): Pair<Jwt, Nonce?> {
+        suspend fun usePOST(): Triple<Jwt, Nonce?, String> {
             ensureNotNull(postOptions) {
                 unsupportedRequestUriMethod(RequestUriMethod.POST)
             }
@@ -97,7 +98,7 @@ internal class RequestFetcher(
                 jwt.decrypt(ephemeralJarEncryptionKey!!, postOptions.jarEncryption).getOrThrow()
             } else jwt
 
-            return signedJwt to walletNonce
+            return Triple(signedJwt, walletNonce, openId4VPConfig.issuer.value)
         }
 
         return when (requestUriMethod) {
@@ -110,6 +111,7 @@ internal class RequestFetcher(
 private fun OpenId4VPConfig.ensureValid(
     expectedClient: String,
     expectedWalletNonce: Nonce?,
+    expectedAudience: String,
     unverifiedJwt: Jwt,
 ): ReceivedRequest.Signed {
     val signedJwt = ensureIsSignedJwt(unverifiedJwt).also(::ensureSupportedSigningAlgorithm)
@@ -117,6 +119,7 @@ private fun OpenId4VPConfig.ensureValid(
     if (expectedWalletNonce != null) {
         ensureSameWalletNonce(expectedWalletNonce, signedJwt)
     }
+    ensureSameAudience(expectedAudience, signedJwt)
     return ReceivedRequest.Signed(signedJwt)
 }
 
@@ -218,3 +221,16 @@ internal suspend fun EncryptionRequirement.Required.ephemeralEncryptionKey(): EC
             .keyUse(KeyUse.ENCRYPTION)
             .generate()
     }
+
+private fun ensureSameAudience(expectedAudience: String, signedJwt: SignedJWT) {
+    val jwtAudience = signedJwt.jwtClaimsSet.audience
+    ensure(!jwtAudience.isNullOrEmpty()) {
+        invalidJwt("JAR is missing '${RFC7519.AUDIENCE}'")
+    }
+    ensure(1 == jwtAudience.size) {
+        invalidJwt("JAR contains more than one values in '${RFC7519.AUDIENCE}'")
+    }
+    ensure(expectedAudience == jwtAudience.first()) {
+        invalidJwt("JAR '${RFC7519.AUDIENCE}' mismatch. Expected: $expectedAudience, found: ${jwtAudience.first()}")
+    }
+}

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
@@ -21,6 +21,7 @@ import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.id.Audience
 import com.nimbusds.openid.connect.sdk.Nonce
 import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.OpenId4VPConfig.Companion.SelfIssued
@@ -50,7 +51,7 @@ internal class RequestFetcher(
         is UnvalidatedRequest.Plain -> ReceivedRequest.Unsigned(request.requestObject)
         is UnvalidatedRequest.JwtSecured -> {
             val (jwt, walletNonce, audience) = when (request) {
-                is UnvalidatedRequest.JwtSecured.PassByValue -> Triple(request.jwt, null, SelfIssued.value)
+                is UnvalidatedRequest.JwtSecured.PassByValue -> Triple(request.jwt, null, Audience(SelfIssued))
                 is UnvalidatedRequest.JwtSecured.PassByReference -> fetchJwtWalletNonceAndAudience(request)
             }
             with(openId4VPConfig) {
@@ -61,21 +62,21 @@ internal class RequestFetcher(
 
     private suspend fun fetchJwtWalletNonceAndAudience(
         request: UnvalidatedRequest.JwtSecured.PassByReference,
-    ): Triple<Jwt, Nonce?, String> {
+    ): Triple<Jwt, Nonce?, Audience> {
         val (_, requestUri, requestUriMethod) = request
 
         val supportedMethods =
             openId4VPConfig.signedRequestConfiguration.supportedRequestUriMethods
         val postOptions = supportedMethods.isPostSupported()
 
-        suspend fun useGET(): Triple<Jwt, Nonce?, String> {
+        suspend fun useGET(): Triple<Jwt, Nonce?, Audience> {
             ensure(supportedMethods.isGetSupported()) {
                 unsupportedRequestUriMethod(RequestUriMethod.GET)
             }
-            return Triple(httpClient.getJAR(requestUri), null, SelfIssued.value)
+            return Triple(httpClient.getJAR(requestUri), null, Audience(SelfIssued))
         }
 
-        suspend fun usePOST(): Triple<Jwt, Nonce?, String> {
+        suspend fun usePOST(): Triple<Jwt, Nonce?, Audience> {
             ensureNotNull(postOptions) {
                 unsupportedRequestUriMethod(RequestUriMethod.POST)
             }
@@ -99,8 +100,10 @@ internal class RequestFetcher(
             } else jwt
 
             val audience =
-                if (null != walletMetaData) checkNotNull(openId4VPConfig.issuer?.value)
-                else SelfIssued.value
+                walletMetaData?.let {
+                    val issuer = openId4VPConfig.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()?.issuer
+                    Audience(checkNotNull(issuer))
+                } ?: Audience(SelfIssued)
 
             return Triple(signedJwt, walletNonce, audience)
         }
@@ -115,7 +118,7 @@ internal class RequestFetcher(
 private fun OpenId4VPConfig.ensureValid(
     expectedClient: String,
     expectedWalletNonce: Nonce?,
-    expectedAudience: String,
+    expectedAudience: Audience,
     unverifiedJwt: Jwt,
 ): ReceivedRequest.Signed {
     val signedJwt = ensureIsSignedJwt(unverifiedJwt).also(::ensureSupportedSigningAlgorithm)
@@ -123,7 +126,9 @@ private fun OpenId4VPConfig.ensureValid(
     if (expectedWalletNonce != null) {
         ensureSameWalletNonce(expectedWalletNonce, signedJwt)
     }
-    ensureSameAudience(expectedAudience, signedJwt)
+    if (signedRequestConfiguration.requestObjectAudienceCheckEnabled) {
+        ensureSameAudience(expectedAudience, signedJwt)
+    }
     return ReceivedRequest.Signed(signedJwt)
 }
 
@@ -226,7 +231,7 @@ internal suspend fun EncryptionRequirement.Required.ephemeralEncryptionKey(): EC
             .generate()
     }
 
-private fun ensureSameAudience(expectedAudience: String, signedJwt: SignedJWT) {
+private fun ensureSameAudience(expectedAudience: Audience, signedJwt: SignedJWT) {
     val jwtAudience = signedJwt.jwtClaimsSet.audience
     ensure(!jwtAudience.isNullOrEmpty()) {
         invalidJwt("JAR is missing '${RFC7519.AUDIENCE}'")
@@ -234,7 +239,7 @@ private fun ensureSameAudience(expectedAudience: String, signedJwt: SignedJWT) {
     ensure(1 == jwtAudience.size) {
         invalidJwt("JAR contains more than one values in '${RFC7519.AUDIENCE}'")
     }
-    ensure(expectedAudience == jwtAudience.first()) {
-        invalidJwt("JAR '${RFC7519.AUDIENCE}' mismatch. Expected: $expectedAudience, found: ${jwtAudience.first()}")
+    ensure(expectedAudience.value == jwtAudience.first()) {
+        invalidJwt("JAR '${RFC7519.AUDIENCE}' mismatch. Expected: ${expectedAudience.value}, found: ${jwtAudience.first()}")
     }
 }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcher.kt
@@ -37,6 +37,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import java.net.URL
 import java.text.ParseException
 
@@ -100,10 +101,12 @@ internal class RequestFetcher(
             } else jwt
 
             val audience =
-                walletMetaData?.let {
-                    val issuer = openId4VPConfig.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()?.issuer
-                    Audience(checkNotNull(issuer))
-                } ?: Audience(SelfIssued)
+                if (null != walletMetaData) {
+                    val issuer = checkNotNull(walletMetaData[RFC8414.ISSUER]?.jsonPrimitive?.content)
+                    Audience(issuer)
+                } else {
+                    Audience(SelfIssued)
+                }
 
             return Triple(signedJwt, walletNonce, audience)
         }

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -41,9 +41,7 @@ internal fun walletMetaData(cfg: OpenId4VPConfig, clientId: String, keys: List<J
         //
         // Authorization Server Metadata
         //
-        if (null != cfg.issuer) {
-            put(RFC8414.ISSUER, cfg.issuer.value)
-        }
+        put(RFC8414.ISSUER, checkNotNull(cfg.issuer?.value))
 
         //
         // Authorization Request signature and encryption parameters

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -39,6 +39,13 @@ private const val RESPONSE_MODES_SUPPORTED = "response_modes_supported"
 internal fun walletMetaData(cfg: OpenId4VPConfig, clientId: String, keys: List<JWK>): JsonObject =
     buildJsonObject {
         //
+        // Authorization Server Metadata
+        //
+        if (null != cfg.issuer) {
+            put(RFC8414.ISSUER, cfg.issuer.value)
+        }
+
+        //
         // Authorization Request signature and encryption parameters
         // Uses properties defined in JAR and JARM specs
         // https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#name-request-uri-method-post

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -41,9 +41,7 @@ internal fun walletMetaData(cfg: OpenId4VPConfig, clientId: String, keys: List<J
         //
         // Authorization Server Metadata
         //
-        if (null != cfg.issuer) {
-            put(RFC8414.ISSUER, cfg.issuer.value)
-        }
+        put(RFC8414.ISSUER, cfg.issuer.value)
 
         //
         // Authorization Request signature and encryption parameters

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -41,9 +41,8 @@ internal fun walletMetaData(cfg: OpenId4VPConfig, clientId: String, keys: List<J
         //
         // Authorization Server Metadata
         //
-        cfg.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()?.issuer?.value?.let { issuer ->
-            put(RFC8414.ISSUER, issuer)
-        }
+        val issuer = checkNotNull(cfg.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()?.issuer)
+        put(RFC8414.ISSUER, issuer.value)
 
         //
         // Authorization Request signature and encryption parameters

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -41,7 +41,9 @@ internal fun walletMetaData(cfg: OpenId4VPConfig, clientId: String, keys: List<J
         //
         // Authorization Server Metadata
         //
-        put(RFC8414.ISSUER, cfg.issuer.value)
+        if (null != cfg.issuer) {
+            put(RFC8414.ISSUER, cfg.issuer.value)
+        }
 
         //
         // Authorization Request signature and encryption parameters

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaData.kt
@@ -41,7 +41,9 @@ internal fun walletMetaData(cfg: OpenId4VPConfig, clientId: String, keys: List<J
         //
         // Authorization Server Metadata
         //
-        put(RFC8414.ISSUER, checkNotNull(cfg.issuer?.value))
+        cfg.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()?.issuer?.value?.let { issuer ->
+            put(RFC8414.ISSUER, issuer)
+        }
 
         //
         // Authorization Request signature and encryption parameters

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
@@ -224,15 +224,13 @@ class ConfigTests {
     @Test
     fun `fails when using request uri method post, wallet metadata, and no issuer`() {
         val exception = assertFailsWith<IllegalArgumentException> {
-            OpenId4VPConfig(
+            SupportedRequestUriMethods.Post(
+                includeWalletMetadata = true,
                 issuer = null,
-                signedRequestConfiguration = SignedRequestConfiguration.Default,
-                vpFormatsSupported = VpFormatsSupported(sdJwtVc = VpFormatsSupported.SdJwtVc.HAIP),
-                supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns { true }),
             )
         }
         assertEquals(
-            "Wrong configuration. Issuer must be provided when using Request URI Method POST and including Wallet Metadata.",
+            "Issuer must be provided when Wallet Metadata is sent",
             exception.message,
         )
     }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/ConfigTests.kt
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.assertDoesNotThrow
 import java.time.Duration
 import java.util.*
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class ConfigTests {
@@ -218,5 +219,21 @@ class ConfigTests {
                 supportedMethods = emptyList(),
             )
         }
+    }
+
+    @Test
+    fun `fails when using request uri method post, wallet metadata, and no issuer`() {
+        val exception = assertFailsWith<IllegalArgumentException> {
+            OpenId4VPConfig(
+                issuer = null,
+                signedRequestConfiguration = SignedRequestConfiguration.Default,
+                vpFormatsSupported = VpFormatsSupported(sdJwtVc = VpFormatsSupported.SdJwtVc.HAIP),
+                supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns { true }),
+            )
+        }
+        assertEquals(
+            "Wrong configuration. Issuer must be provided when using Request URI Method POST and including Wallet Metadata.",
+            exception.message,
+        )
     }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
@@ -141,6 +141,39 @@ internal class RequestFetcherTest {
     }
 
     @Test
+    fun `request uri method post - fetch signed request object on audience mismatch with check disabled`() = runTest {
+        val issuer = "eudi_wallet"
+        val clientId = "verifier"
+        val jarEncryptionRequirement = EncryptionRequirement.NotRequired
+        val config = config(issuer = issuer, clientId = clientId, jarEncryptionRequirement, requestObjectAudienceCheckEnabled = false)
+        val requestUri = URI.create("https://verifier/signed-request")
+
+        lateinit var signedRequest: SignedJWT
+        val engine = MockEngine(requestUri, jarEncryptionRequirement) { encryptionKey, walletNonce ->
+            assertNull(encryptionKey)
+
+            signedRequest = createSignedRequestObject(audience = SelfIssued.value, clientId = clientId, walletNonce = walletNonce)
+
+            respond(
+                content = signedRequest.serialize(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf("application/oauth-authz-req+jwt")),
+            )
+        }
+        val client = createHttpClient(httpEngine = engine)
+
+        val fetcher = RequestFetcher(client, config)
+        val request = UnvalidatedRequest.JwtSecured.PassByReference(
+            clientId = clientId,
+            jwtURI = requestUri.toURL(),
+            requestURIMethod = RequestUriMethod.POST,
+        )
+
+        val receivedRequest = assertIs<ReceivedRequest.Signed>(fetcher.fetchRequest(request))
+        assertEquals(signedRequest.serialize(), receivedRequest.toSignedJwts()[0].serialize())
+    }
+
+    @Test
     fun `request uri method post - decryption fails when jar is not encrypted with jwk in jwks`() = runTest {
         val issuer = "eudi_wallet"
         val clientId = "verifier"
@@ -232,16 +265,18 @@ private fun config(
     issuer: String,
     clientId: String,
     jarEncryptionRequirement: EncryptionRequirement,
+    requestObjectAudienceCheckEnabled: Boolean = true,
 ): OpenId4VPConfig =
     OpenId4VPConfig(
-        issuer = Issuer(issuer),
         signedRequestConfiguration = SignedRequestConfiguration(
             supportedAlgorithms = JWSAlgorithm.Family.EC.toList() - JWSAlgorithm.ES256K,
             supportedRequestUriMethods = SupportedRequestUriMethods.Post(
                 includeWalletMetadata = true,
                 jarEncryption = jarEncryptionRequirement,
                 useWalletNonce = NonceOption.Use(),
+                issuer = Issuer(issuer),
             ),
+            requestObjectAudienceCheckEnabled = requestObjectAudienceCheckEnabled,
         ),
         vpFormatsSupported = VpFormatsSupported(
             VpFormatsSupported.SdJwtVc.HAIP,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/RequestFetcherTest.kt
@@ -24,7 +24,9 @@ import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.id.Issuer
 import eu.europa.ec.eudi.openid4vp.*
+import eu.europa.ec.eudi.openid4vp.OpenId4VPConfig.Companion.SelfIssued
 import eu.europa.ec.eudi.openid4vp.internal.JwsJson.Companion.flatten
 import io.ktor.client.engine.mock.*
 import io.ktor.client.request.*
@@ -43,9 +45,10 @@ internal class RequestFetcherTest {
 
     @Test
     fun `request uri method post - fetching fails on error`() = runTest {
+        val issuer = "eudi_wallet"
         val clientId = "verifier"
         val jarEncryptionRequirement = EncryptionRequirement.NotRequired
-        val config = config(clientId, jarEncryptionRequirement)
+        val config = config(issuer = issuer, clientId = clientId, jarEncryptionRequirement)
         val requestUri = URI.create("https://verifier/signed-request")
 
         val engine = MockEngine(requestUri, jarEncryptionRequirement) { encryptionKey, walletNonce ->
@@ -68,17 +71,55 @@ internal class RequestFetcherTest {
     }
 
     @Test
-    fun `request uri method post - fetch signed request object`() = runTest {
+    fun `request uri method post - fails on audience mismatch`() = runTest {
+        val issuer = "eudi_wallet"
         val clientId = "verifier"
         val jarEncryptionRequirement = EncryptionRequirement.NotRequired
-        val config = config(clientId, jarEncryptionRequirement)
+        val config = config(issuer = issuer, clientId = clientId, jarEncryptionRequirement)
         val requestUri = URI.create("https://verifier/signed-request")
 
         lateinit var signedRequest: SignedJWT
         val engine = MockEngine(requestUri, jarEncryptionRequirement) { encryptionKey, walletNonce ->
             assertNull(encryptionKey)
 
-            signedRequest = createSignedRequestObject(clientId, walletNonce)
+            signedRequest = createSignedRequestObject(audience = SelfIssued.value, clientId = clientId, walletNonce = walletNonce)
+
+            respond(
+                content = signedRequest.serialize(),
+                status = HttpStatusCode.OK,
+                headers = headersOf(HttpHeaders.ContentType to listOf("application/oauth-authz-req+jwt")),
+            )
+        }
+        val client = createHttpClient(httpEngine = engine)
+
+        val fetcher = RequestFetcher(client, config)
+        val exception = assertFailsWith(AuthorizationRequestException::class) {
+            val request = UnvalidatedRequest.JwtSecured.PassByReference(
+                clientId = clientId,
+                jwtURI = requestUri.toURL(),
+                requestURIMethod = RequestUriMethod.POST,
+            )
+            fetcher.fetchRequest(request)
+        }
+        assertEquals(
+            RequestValidationError.InvalidJarJwt("JAR '${RFC7519.AUDIENCE}' mismatch. Expected: $issuer, found: ${SelfIssued.value}"),
+            exception.error,
+        )
+    }
+
+    @Test
+    fun `request uri method post - fetch signed request object`() = runTest {
+        val issuer = "eudi_wallet"
+        val clientId = "verifier"
+        val jarEncryptionRequirement = EncryptionRequirement.NotRequired
+        val config = config(issuer = issuer, clientId = clientId, jarEncryptionRequirement)
+        val requestUri = URI.create("https://verifier/signed-request")
+
+        lateinit var signedRequest: SignedJWT
+        val engine = MockEngine(requestUri, jarEncryptionRequirement) { encryptionKey, walletNonce ->
+            assertNull(encryptionKey)
+
+            signedRequest = createSignedRequestObject(audience = issuer, clientId = clientId, walletNonce = walletNonce)
 
             respond(
                 content = signedRequest.serialize(),
@@ -101,20 +142,21 @@ internal class RequestFetcherTest {
 
     @Test
     fun `request uri method post - decryption fails when jar is not encrypted with jwk in jwks`() = runTest {
+        val issuer = "eudi_wallet"
         val clientId = "verifier"
         val jarEncryptionRequirement = EncryptionRequirement.Required(
             supportedEncryptionAlgorithms = listOf(JWEAlgorithm.ECDH_ES),
             supportedEncryptionMethods = listOf(EncryptionMethod.A256GCM),
             ephemeralEncryptionKeyCurve = Curve.P_521,
         )
-        val config = config(clientId, jarEncryptionRequirement)
+        val config = config(issuer = issuer, clientId = clientId, jarEncryptionRequirement)
         val requestUri = URI.create("https://verifier/encrypted-request")
 
         lateinit var signedRequest: SignedJWT
         val engine =
             MockEngine(requestUri, jarEncryptionRequirement) { encryptionKey, walletNonce ->
                 assertNotNull(encryptionKey)
-                signedRequest = createSignedRequestObject(clientId, walletNonce)
+                signedRequest = createSignedRequestObject(audience = issuer, clientId = clientId, walletNonce = walletNonce)
                 val encryptedRequest = createEncryptedRequestObject(
                     signedRequest,
                     ECKeyGenerator(jarEncryptionRequirement.ephemeralEncryptionKeyCurve).generate(),
@@ -144,20 +186,21 @@ internal class RequestFetcherTest {
 
     @Test
     fun `request uri method post - fetch encrypted and signed request object`() = runTest {
+        val issuer = "eudi_wallet"
         val clientId = "verifier"
         val jarEncryptionRequirement = EncryptionRequirement.Required(
             supportedEncryptionAlgorithms = listOf(JWEAlgorithm.ECDH_ES),
             supportedEncryptionMethods = listOf(EncryptionMethod.A256GCM),
             ephemeralEncryptionKeyCurve = Curve.P_521,
         )
-        val config = config(clientId, jarEncryptionRequirement)
+        val config = config(issuer = issuer, clientId = clientId, jarEncryptionRequirement)
         val requestUri = URI.create("https://verifier/encrypted-request")
 
         lateinit var signedRequest: SignedJWT
         val engine =
             MockEngine(requestUri, jarEncryptionRequirement) { encryptionKey, walletNonce ->
                 assertNotNull(encryptionKey)
-                signedRequest = createSignedRequestObject(clientId, walletNonce)
+                signedRequest = createSignedRequestObject(audience = issuer, clientId = clientId, walletNonce = walletNonce)
                 val encryptedRequest = createEncryptedRequestObject(
                     signedRequest,
                     encryptionKey,
@@ -185,8 +228,13 @@ internal class RequestFetcherTest {
     }
 }
 
-private fun config(clientId: String, jarEncryptionRequirement: EncryptionRequirement): OpenId4VPConfig =
+private fun config(
+    issuer: String,
+    clientId: String,
+    jarEncryptionRequirement: EncryptionRequirement,
+): OpenId4VPConfig =
     OpenId4VPConfig(
+        issuer = Issuer(issuer),
         signedRequestConfiguration = SignedRequestConfiguration(
             supportedAlgorithms = JWSAlgorithm.Family.EC.toList() - JWSAlgorithm.ES256K,
             supportedRequestUriMethods = SupportedRequestUriMethods.Post(
@@ -205,10 +253,15 @@ private fun config(clientId: String, jarEncryptionRequirement: EncryptionRequire
         supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.Preregistered(PreregisteredClient(clientId, clientId))),
     )
 
-private fun createSignedRequestObject(clientId: String, walletNonce: String): SignedJWT =
+private fun createSignedRequestObject(
+    audience: String,
+    clientId: String,
+    walletNonce: String,
+): SignedJWT =
     SignedJWT(
         JWSHeader.Builder(JWSAlgorithm.ES256).build(),
         JWTClaimsSet.Builder()
+            .audience(audience)
             .claim("client_id", clientId)
             .claim(OpenId4VPSpec.WALLET_NONCE, walletNonce)
             .build(),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -49,6 +49,7 @@ class WalletMetaDataTest {
                         ephemeralEncryptionKeyCurve = Curve.P_521,
                     ),
                 ),
+                requestObjectAudienceCheckEnabled = true,
             ),
         )
         assertMetadata(config, "x509_san_dns:verifier.example.com")
@@ -120,7 +121,8 @@ private suspend fun assertMetadata(config: OpenId4VPConfig, clientId: String) {
     assertJarSigning(config, clientId, walletMetaData)
     assertJarEncryption(encryptionRequirement, ephemeralJarEncryptionJwks, walletMetaData)
     assertResponseTypes(walletMetaData)
-    assertIssuer(config.issuer, walletMetaData)
+    val issuer = config.signedRequestConfiguration.supportedRequestUriMethods.isPostSupported()?.issuer
+    assertIssuer(issuer, walletMetaData)
 }
 
 private fun assertJarSigning(config: OpenId4VPConfig, clientId: String, walletMetaData: JsonObject) {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -74,22 +74,6 @@ class WalletMetaDataTest {
     }
 
     @Test
-    fun `test without issuer`() = runTest {
-        val config = OpenId4VPConfig(
-            issuer = null,
-            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
-            vpFormatsSupported = VpFormatsSupported(
-                VpFormatsSupported.SdJwtVc.HAIP,
-                VpFormatsSupported.MsoMdoc(
-                    issuerAuthAlgorithms = listOf(CoseAlgorithm(-7)),
-                    deviceAuthAlgorithms = listOf(CoseAlgorithm(-7)),
-                ),
-            ),
-        )
-        assertMetadata(config, "x509_san_dns:verifier.example.com")
-    }
-
-    @Test
     fun `when clientId permits signed Request Objects, request_object_signing_alg_values_supported MUST be included`() = runTest {
         val config = OpenId4VPConfig(
             supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
@@ -261,12 +245,8 @@ private fun assertResponseTypes(walletMetadata: JsonObject) {
     assert("vp_token" in values) { "'response_types_supported' misses 'vp_token'" }
 }
 
-private fun assertIssuer(issuer: Issuer?, walletMetadata: JsonObject) {
-    if (null != issuer) {
-        val issuerInWalletMetadata = assertIs<JsonPrimitive>(walletMetadata[RFC8414.ISSUER])
-        assertTrue(issuerInWalletMetadata.isString)
-        assertEquals(issuer.value, issuerInWalletMetadata.content)
-    } else {
-        assertNull(walletMetadata[RFC8414.ISSUER])
-    }
+private fun assertIssuer(issuer: Issuer, walletMetadata: JsonObject) {
+    val issuerInWalletMetadata = assertIs<JsonPrimitive>(walletMetadata[RFC8414.ISSUER])
+    assertTrue(issuerInWalletMetadata.isString)
+    assertEquals(issuer.value, issuerInWalletMetadata.content)
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -20,6 +20,7 @@ import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.oauth2.sdk.id.Issuer
 import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.internal.jsonSupport
 import kotlinx.coroutines.test.runTest
@@ -73,6 +74,22 @@ class WalletMetaDataTest {
     }
 
     @Test
+    fun `test without issuer`() = runTest {
+        val config = OpenId4VPConfig(
+            issuer = null,
+            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
+            vpFormatsSupported = VpFormatsSupported(
+                VpFormatsSupported.SdJwtVc.HAIP,
+                VpFormatsSupported.MsoMdoc(
+                    issuerAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                    deviceAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                ),
+            ),
+        )
+        assertMetadata(config, "x509_san_dns:verifier.example.com")
+    }
+
+    @Test
     fun `when clientId permits signed Request Objects, request_object_signing_alg_values_supported MUST be included`() = runTest {
         val config = OpenId4VPConfig(
             supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
@@ -119,6 +136,7 @@ private suspend fun assertMetadata(config: OpenId4VPConfig, clientId: String) {
     assertJarSigning(config, clientId, walletMetaData)
     assertJarEncryption(encryptionRequirement, ephemeralJarEncryptionJwks, walletMetaData)
     assertResponseTypes(walletMetaData)
+    assertIssuer(config.issuer, walletMetaData)
 }
 
 private fun assertJarSigning(config: OpenId4VPConfig, clientId: String, walletMetaData: JsonObject) {
@@ -241,4 +259,14 @@ private fun assertResponseTypes(walletMetadata: JsonObject) {
     val values = types.map { it.jsonPrimitive.content }
     assertEquals(1, values.size, "'unexpected number of 'response_types_supported'")
     assert("vp_token" in values) { "'response_types_supported' misses 'vp_token'" }
+}
+
+private fun assertIssuer(issuer: Issuer?, walletMetadata: JsonObject) {
+    if (null != issuer) {
+        val issuerInWalletMetadata = assertIs<JsonPrimitive>(walletMetadata[RFC8414.ISSUER])
+        assertTrue(issuerInWalletMetadata.isString)
+        assertEquals(issuer.value, issuerInWalletMetadata.content)
+    } else {
+        assertNull(walletMetadata[RFC8414.ISSUER])
+    }
 }

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -74,22 +74,6 @@ class WalletMetaDataTest {
     }
 
     @Test
-    fun `test without issuer`() = runTest {
-        val config = OpenId4VPConfig(
-            issuer = null,
-            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
-            vpFormatsSupported = VpFormatsSupported(
-                VpFormatsSupported.SdJwtVc.HAIP,
-                VpFormatsSupported.MsoMdoc(
-                    issuerAuthAlgorithms = listOf(CoseAlgorithm(-7)),
-                    deviceAuthAlgorithms = listOf(CoseAlgorithm(-7)),
-                ),
-            ),
-        )
-        assertMetadata(config, "x509_san_dns:verifier.example.com")
-    }
-
-    @Test
     fun `when clientId permits signed Request Objects, request_object_signing_alg_values_supported MUST be included`() = runTest {
         val config = OpenId4VPConfig(
             supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -68,7 +68,7 @@ class WalletMetaDataTest {
             ),
             signedRequestConfiguration = SignedRequestConfiguration(
                 supportedAlgorithms = SignedRequestConfiguration.Default.supportedAlgorithms,
-                supportedRequestUriMethods = SupportedRequestUriMethods.Get,
+                supportedRequestUriMethods = SupportedRequestUriMethods.Default,
             ),
         )
         assertMetadata(config, "x509_san_dns:verifier.example.com")

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/request/WalletMetaDataTest.kt
@@ -74,6 +74,22 @@ class WalletMetaDataTest {
     }
 
     @Test
+    fun `test without issuer`() = runTest {
+        val config = OpenId4VPConfig(
+            issuer = null,
+            supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
+            vpFormatsSupported = VpFormatsSupported(
+                VpFormatsSupported.SdJwtVc.HAIP,
+                VpFormatsSupported.MsoMdoc(
+                    issuerAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                    deviceAuthAlgorithms = listOf(CoseAlgorithm(-7)),
+                ),
+            ),
+        )
+        assertMetadata(config, "x509_san_dns:verifier.example.com")
+    }
+
+    @Test
     fun `when clientId permits signed Request Objects, request_object_signing_alg_values_supported MUST be included`() = runTest {
         val config = OpenId4VPConfig(
             supportedClientIdPrefixes = listOf(SupportedClientIdPrefix.X509SanDns.NoValidation),
@@ -245,8 +261,12 @@ private fun assertResponseTypes(walletMetadata: JsonObject) {
     assert("vp_token" in values) { "'response_types_supported' misses 'vp_token'" }
 }
 
-private fun assertIssuer(issuer: Issuer, walletMetadata: JsonObject) {
-    val issuerInWalletMetadata = assertIs<JsonPrimitive>(walletMetadata[RFC8414.ISSUER])
-    assertTrue(issuerInWalletMetadata.isString)
-    assertEquals(issuer.value, issuerInWalletMetadata.content)
+private fun assertIssuer(issuer: Issuer?, walletMetadata: JsonObject) {
+    if (null != issuer) {
+        val issuerInWalletMetadata = assertIs<JsonPrimitive>(walletMetadata[RFC8414.ISSUER])
+        assertTrue(issuerInWalletMetadata.isString)
+        assertEquals(issuer.value, issuerInWalletMetadata.content)
+    } else {
+        assertNull(walletMetadata[RFC8414.ISSUER])
+    }
 }


### PR DESCRIPTION
This PR:

1. Introduces `SupportedRequetsUriMethod.Post.issuer`. Defaults to `https://self-issued.me/v2` and is requred when `includeWalletMetadata` is `true`;
2. Communicates `SupportedRequetsUriMethod.Post.issuer` via Authorization Server Metadata when using Request URI Method `POST` and Wallet Metadata are included in the request;
3. Marks `OpenId4VPConfig.issuer` as deprecated;
4. Introduced `SignedRequestConfiguration.requestObjectAudienceCheckEnabled` to control whether the Audience of the Request Object is checked or not. Defaults to `true`;
5. Adds missing validation of `aud` when using JAR;
6. Update README, documenting the current behavior of the library, and how to disable the Request Object Audience Check;

Fixes #437 