### PR TITLE
Fix 504

### DIFF
--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/ResponseDispatching.kt
@@ -65,10 +65,12 @@ sealed interface DispatchOutcome : java.io.Serializable {
 
         /**
          * When verifier/RP reject the direct post
+         *
+         * @property redirectURI OPTIONAL. A URI provided by the verifier to which the wallet must
+         * redirect the user agent, as defined by OpenID4VP. The Response URI MAY return the
+         * redirect_uri parameter in response to error responses.
          */
-        data object Rejected : VerifierResponse {
-            private fun readResolve(): Any = Rejected
-        }
+        data class Rejected(val redirectURI: URI?) : VerifierResponse
     }
 }
 

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverHttp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverHttp.kt
@@ -19,9 +19,9 @@ import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponse.*
 import io.ktor.client.*
 import io.ktor.client.call.*
-import io.ktor.client.plugins.expectSuccess
+import io.ktor.client.plugins.*
 import io.ktor.client.request.*
-import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
@@ -102,16 +102,27 @@ internal class DefaultDispatcherOverHttp(
      * as defined by OpenID4VP. The Response URI MAY return the redirect_uri parameter in
      * response to successful Authorization Responses or for Error Responses.
      */
-    private suspend fun HttpResponse.parseRedirectUri(): URI? =
-        try {
-            body<JsonObject?>()
-                ?.get("redirect_uri")
-                ?.takeIf { it is JsonPrimitive }
-                ?.jsonPrimitive?.contentOrNull
-                ?.let { URI.create(it) }
-        } catch (_: NoTransformationFoundException) {
-            null
+    @Throws(IllegalArgumentException::class)
+    private suspend fun HttpResponse.parseRedirectUri(): URI? {
+        val body = runCatchingCancellable { body<JsonObject?>() }.getOrElse { ex ->
+            val exceptionToRaise = when (ex) {
+                is IllegalArgumentException -> ex
+                is NoTransformationFoundException -> IllegalStateException("Http client doesn't seem to support content negotiation", ex)
+                else -> IllegalArgumentException("Failed to parse Verifier response", ex)
+            }
+            throw exceptionToRaise
         }
+        return body?.let { response ->
+            response["redirect_uri"]?.let { redirectUri ->
+                require(redirectUri is JsonPrimitive && redirectUri.isString) {
+                    "Verifier sent a redirect_uri that is not a string"
+                }
+                runCatchingCancellable { URI.create(redirectUri.content) }.getOrElse { ex ->
+                    throw IllegalArgumentException("Verifier sent a redirect_uri that is not a valid URI", ex)
+                }
+            }
+        }
+    }
 
     override suspend fun encodeRedirectURI(
         request: ResolvedRequestObject,

--- a/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverHttp.kt
+++ b/src/main/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherOverHttp.kt
@@ -19,7 +19,9 @@ import eu.europa.ec.eudi.openid4vp.*
 import eu.europa.ec.eudi.openid4vp.internal.response.AuthorizationResponse.*
 import io.ktor.client.*
 import io.ktor.client.call.*
+import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.request.*
+import io.ktor.client.statement.HttpResponse
 import io.ktor.http.*
 import io.ktor.http.content.*
 import io.ktor.utils.io.*
@@ -83,28 +85,33 @@ internal class DefaultDispatcherOverHttp(
         url: URL,
         parameters: Parameters,
     ): DispatchOutcome.VerifierResponse {
-        val response = httpClient.post(url.toExternalForm()) {
-            body = FormData(parameters)
-        }
-
-        return when (response.status) {
-            HttpStatusCode.OK -> {
-                val redirectUri =
-                    try {
-                        response.body<JsonObject?>()
-                            ?.get("redirect_uri")
-                            ?.takeIf { it is JsonPrimitive }
-                            ?.jsonPrimitive?.contentOrNull
-                            ?.let { URI.create(it) }
-                    } catch (_: NoTransformationFoundException) {
-                        null
-                    }
-                DispatchOutcome.VerifierResponse.Accepted(redirectUri)
+        val response =
+            httpClient.post(url.toExternalForm()) {
+                expectSuccess = false
+                body = FormData(parameters)
             }
-
-            else -> DispatchOutcome.VerifierResponse.Rejected
+        val redirectUri = response.parseRedirectUri()
+        return when {
+            response.status.isSuccess() -> DispatchOutcome.VerifierResponse.Accepted(redirectUri)
+            else -> DispatchOutcome.VerifierResponse.Rejected(redirectUri)
         }
     }
+
+    /**
+     * Extracts the optional `redirect_uri` returned by the verifier in the response body,
+     * as defined by OpenID4VP. The Response URI MAY return the redirect_uri parameter in
+     * response to successful Authorization Responses or for Error Responses.
+     */
+    private suspend fun HttpResponse.parseRedirectUri(): URI? =
+        try {
+            body<JsonObject?>()
+                ?.get("redirect_uri")
+                ?.takeIf { it is JsonPrimitive }
+                ?.jsonPrimitive?.contentOrNull
+                ?.let { URI.create(it) }
+        } catch (_: NoTransformationFoundException) {
+            null
+        }
 
     override suspend fun encodeRedirectURI(
         request: ResolvedRequestObject,

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/Example.kt
@@ -91,7 +91,7 @@ suspend fun HttpClient.program() {
         when (val dispatchOutcome = wallet.handle(verifier.authorizationRequestUri)) {
             is DispatchOutcome.RedirectURI -> error("Unexpected")
             is DispatchOutcome.VerifierResponse.Accepted -> verifier.getWalletResponse(dispatchOutcome)
-            DispatchOutcome.VerifierResponse.Rejected -> error("Unexpected failure")
+            is DispatchOutcome.VerifierResponse.Rejected -> error("Unexpected failure")
         }
     }
 

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -451,9 +451,18 @@ class DefaultDispatcherTest {
                     assertEquals("invalid_scope", body.formData["error"])
                     assertEquals("UnknownScope(scope=Scope(value=openid))", body.formData["error_description"])
                     assertEquals(state, body.formData["state"])
-                    respondOk()
+                    val responseBody = buildJsonObject { }
+                    respond(
+                        content = Json.encodeToString(responseBody),
+                        status = HttpStatusCode.OK,
+                        headers = headers {
+                            set(HttpHeaders.ContentType, "application/json")
+                        },
+                    )
                 }
-                val httpClient = HttpClient(mockEngine)
+                val httpClient = HttpClient(mockEngine) {
+                    install(ContentNegotiation) { json() }
+                }
                 DefaultDispatcherOverHttp(httpClient)
             }
 
@@ -894,65 +903,69 @@ class DefaultDispatcherTest {
         }
 
         @Test
-        fun `if response mode is dc_api jwt, positive consensus is assembled as an encrypted response embedded in JsonObject`() = runTest {
-            val dcApiDispatcher = DefaultDCApiResponseBuilder()
+        fun `if response mode is dc_api jwt, positive consensus is assembled as an encrypted response embedded in JsonObject`() =
+            runTest {
+                val dcApiDispatcher = DefaultDCApiResponseBuilder()
 
-            val state = genState()
+                val state = genState()
 
-            val query = DCQL(
-                credentials = Credentials(testCredentialQuery()),
-            )
-
-            val clientMetadataValidated =
-                ClientMetaDataValidator.validateClientMetaData(
-                    Verifier.metaDataRequestingEncryptedResponse,
-                    ResponseMode.DCApiJwt,
-                    query,
-                    Wallet.config.responseEncryptionConfiguration,
-                    Wallet.config.vpFormatsSupported,
+                val query = DCQL(
+                    credentials = Credentials(testCredentialQuery()),
                 )
 
-            val resolvedRequestObject = createResolvedRequestObject(
-                validatedClientMetaData = clientMetadataValidated,
-                query = query,
-                state = state,
-                responseMode = ResponseMode.DCApiJwt,
-            )
+                val clientMetadataValidated =
+                    ClientMetaDataValidator.validateClientMetaData(
+                        Verifier.metaDataRequestingEncryptedResponse,
+                        ResponseMode.DCApiJwt,
+                        query,
+                        Wallet.config.responseEncryptionConfiguration,
+                        Wallet.config.vpFormatsSupported,
+                    )
 
-            val consensus = Consensus.PositiveConsensus(
-                VerifiablePresentations(
-                    mapOf(
-                        QueryId("my_credential") to listOf(VerifiablePresentation.Generic("dummy_vp_token")),
+                val resolvedRequestObject = createResolvedRequestObject(
+                    validatedClientMetaData = clientMetadataValidated,
+                    query = query,
+                    state = state,
+                    responseMode = ResponseMode.DCApiJwt,
+                )
+
+                val consensus = Consensus.PositiveConsensus(
+                    VerifiablePresentations(
+                        mapOf(
+                            QueryId("my_credential") to listOf(VerifiablePresentation.Generic("dummy_vp_token")),
+                        ),
                     ),
-                ),
-            )
+                )
 
-            val apu = "dummy_apu"
-            val dcApiResponse = dcApiDispatcher.assembleResponse(
-                resolvedRequestObject,
-                consensus,
-                EncryptionParameters.DiffieHellman(Base64URL.encode(apu)),
-            )
+                val apu = "dummy_apu"
+                val dcApiResponse = dcApiDispatcher.assembleResponse(
+                    resolvedRequestObject,
+                    consensus,
+                    EncryptionParameters.DiffieHellman(Base64URL.encode(apu)),
+                )
 
-            val response = dcApiResponse.get("response")
-            assertNotNull(response)
-            assertIs<JsonPrimitive>(response)
+                val response = dcApiResponse.get("response")
+                assertNotNull(response)
+                assertIs<JsonPrimitive>(response)
 
-            val encryptedResponse = response.content.assertIsJwtEncryptedWithVerifiersPublicKey()
-            assertEquals(Base64URL.encode(resolvedRequestObject.nonce), encryptedResponse.header.agreementPartyVInfo)
-            assertEquals(Base64URL.encode(apu), encryptedResponse.header.agreementPartyUInfo)
+                val encryptedResponse = response.content.assertIsJwtEncryptedWithVerifiersPublicKey()
+                assertEquals(
+                    Base64URL.encode(resolvedRequestObject.nonce),
+                    encryptedResponse.header.agreementPartyVInfo,
+                )
+                assertEquals(Base64URL.encode(apu), encryptedResponse.header.agreementPartyUInfo)
 
-            val vpTokenJO = encryptedResponse.jwtClaimsSet.getJSONObjectClaim("vp_token")
-            assertNotNull(vpTokenJO)
+                val vpTokenJO = encryptedResponse.jwtClaimsSet.getJSONObjectClaim("vp_token")
+                assertNotNull(vpTokenJO)
 
-            val queryIdResponse = vpTokenJO.get("my_credential")
-            assertNotNull(queryIdResponse)
-            assertIs<List<String>>(queryIdResponse)
+                val queryIdResponse = vpTokenJO.get("my_credential")
+                assertNotNull(queryIdResponse)
+                assertIs<List<String>>(queryIdResponse)
 
-            val stateInResponse = encryptedResponse.jwtClaimsSet.getStringClaim("state")
-            assertNotNull(stateInResponse)
-            assertEquals(state, stateInResponse)
-        }
+                val stateInResponse = encryptedResponse.jwtClaimsSet.getStringClaim("state")
+                assertNotNull(stateInResponse)
+                assertEquals(state, stateInResponse)
+            }
 
         @Test
         fun `if response dc_api, negative consensus is assembled as JsonObject`() = runTest {

--- a/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
+++ b/src/test/kotlin/eu/europa/ec/eudi/openid4vp/internal/response/DefaultDispatcherTest.kt
@@ -367,6 +367,71 @@ class DefaultDispatcherTest {
         }
 
         @Test
+        fun `verifier rejection with redirect_uri is reported as Rejected carrying the redirect_uri`() = runTest {
+            val verifierRequest = Verifier.createOpenId4VPRequest(
+                Verifier.metaDataRequestingEncryptedResponse,
+                ResponseMode.DirectPostJwt("https://respond.here".asHttpsURL().getOrThrow()),
+            )
+            val redirectUri = URI.create("https://redirect.here")
+
+            val mockEngine = MockEngine { request ->
+                assertEquals(HttpMethod.Post, request.method)
+                val body = assertIs<FormData>(request.body)
+                assertNotNull(body.formData["response"])
+                respond(
+                    buildJsonObject { put("redirect_uri", JsonPrimitive(redirectUri.toString())) }.toString(),
+                    HttpStatusCode.BadRequest,
+                    headers { append(HttpHeaders.ContentType, ContentType.Application.Json) },
+                )
+            }
+            val httpClient = createHttpClient(mockEngine).config {
+                expectSuccess = true
+                install(ContentNegotiation) { json() }
+            }
+            val dispatcher = DefaultDispatcherOverHttp(httpClient)
+
+            val outcome = dispatcher.dispatch(
+                verifierRequest,
+                Consensus.NegativeConsensus,
+                EncryptionParameters.DiffieHellman(Base64URL.encode("dummy_apu")),
+            )
+            val rejected = assertIs<DispatchOutcome.VerifierResponse.Rejected>(outcome)
+            assertEquals(redirectUri, rejected.redirectURI)
+        }
+
+        @Test
+        fun `verifier rejection without redirect_uri is reported as Rejected with null redirect_uri`() = runTest {
+            val verifierRequest = Verifier.createOpenId4VPRequest(
+                Verifier.metaDataRequestingEncryptedResponse,
+                ResponseMode.DirectPostJwt("https://respond.here".asHttpsURL().getOrThrow()),
+            )
+
+            val mockEngine = MockEngine { request ->
+                assertEquals(HttpMethod.Post, request.method)
+                val body = assertIs<FormData>(request.body)
+                assertNotNull(body.formData["response"])
+                respond(
+                    "",
+                    HttpStatusCode.BadRequest,
+                    headers { append(HttpHeaders.ContentType, ContentType.Application.Json) },
+                )
+            }
+            val httpClient = createHttpClient(mockEngine).config {
+                expectSuccess = true
+                install(ContentNegotiation) { json() }
+            }
+            val dispatcher = DefaultDispatcherOverHttp(httpClient)
+
+            val outcome = dispatcher.dispatch(
+                verifierRequest,
+                Consensus.NegativeConsensus,
+                EncryptionParameters.DiffieHellman(Base64URL.encode("dummy_apu")),
+            )
+            val rejected = assertIs<DispatchOutcome.VerifierResponse.Rejected>(outcome)
+            assertNull(rejected.redirectURI)
+        }
+
+        @Test
         fun `unencrypted errors are sent when using direct_post_jwt`() = runTest {
             val responseMode = ResponseMode.DirectPostJwt("https://respond.here".asHttpsURL().getOrThrow())
             val error = ResolutionError.UnknownScope(Scope.OpenId)


### PR DESCRIPTION
Closes #504 

>[!NOTE]
The PR introduces an minor breaking change to the representation of negative verifier response in order to introduce the optional attribute for `redirect_uri`


 